### PR TITLE
Refinement of Java DataSet API (flink-java) annotations

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/functions/FunctionAnnotation.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Retention;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 
 /**
@@ -76,6 +77,7 @@ import org.apache.flink.api.common.InvalidProgramException;
  * </b>
  *
  */
+@PublicInterface
 public class FunctionAnnotation {
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -21,6 +21,8 @@ package org.apache.flink.api.java.io;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.operators.DataSource;
@@ -40,6 +42,7 @@ import com.google.common.base.Preconditions;
  * the delimiters (row and field),  the fields that should be included or skipped, and other flags
  * such as whether to skip the initial line as the header.
  */
+@PublicInterface
 public class CsvReader {
 
 	private final Path path;
@@ -107,6 +110,7 @@ public class CsvReader {
 	 * @return The CSV reader instance itself, to allow for fluent function chaining.
 	 */
 	@Deprecated
+	@PublicExperimental
 	public CsvReader fieldDelimiter(char delimiter) {
 		this.fieldDelimiter = String.valueOf(delimiter);
 		return this;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/DiscardingOutputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/DiscardingOutputFormat.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.api.java.io;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.configuration.Configuration;
 
@@ -27,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
  *
  * @param <T> The type of the elements accepted by the output format.
  */
+@PublicInterface
 public class DiscardingOutputFormat<T> implements OutputFormat<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/SplitDataProperties.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/SplitDataProperties.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.io;
 
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.GenericDataSourceBase;
@@ -56,6 +57,7 @@ import java.util.Arrays;
  * @see org.apache.flink.api.common.io.InputFormat
  * @see org.apache.flink.api.java.operators.DataSource
  */
+@PublicExperimental
 public class SplitDataProperties<T> implements GenericDataSourceBase.SplitDataProperties<T> {
 
 	private TypeInformation<T> type;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -21,11 +21,12 @@ package org.apache.flink.api.java.io;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.DelimitedInputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 
-
+@PublicInterface
 public class TextInputFormat extends DelimitedInputFormat<String> {
 	
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextOutputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextOutputFormat.java
@@ -24,10 +24,11 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.core.fs.Path;
 
-
+@PublicInterface
 public class TextOutputFormat<T> extends FileOutputFormat<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/BulkIterationResultSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/BulkIterationResultSet.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 
+@PublicInterface
 public class BulkIterationResultSet<T> extends DataSet<T> {
 
 	private final IterativeDataSet<T> iterationHead;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupOperator.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -64,6 +65,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
  * 
  * @see DataSet
  */
+@PublicInterface
 public class CoGroupOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, CoGroupOperator<I1, I2, OUT>> {
 
 	private final CoGroupFunction<I1, I2, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupRawOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CoGroupRawOperator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.Function;
@@ -36,6 +37,7 @@ import org.apache.flink.api.java.operators.Keys.IncompatibleKeysException;
  * 
  * @see DataSet
  */
+@PublicInterface
 public class CoGroupRawOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, CoGroupRawOperator<I1, I2, OUT>> {
 
 	private final CoGroupFunction<I1, I2, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/CustomUnaryOperation.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/CustomUnaryOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.java.DataSet;
 
 /**
@@ -25,6 +26,7 @@ import org.apache.flink.api.java.DataSet;
  * @param <IN> The type of the data set consumed by this operator.
  * @param <OUT> The type of the data set produced by this operator. 
  */
+@PublicInterface
 public interface CustomUnaryOperation<IN, OUT> {
 	
 	void setInput(DataSet<IN> inputData);

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSink.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.operators;
 
 import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.GenericDataSinkBase;
@@ -108,6 +109,7 @@ public class DataSink<T> {
 	 * @see org.apache.flink.api.java.tuple.Tuple
 	 * @see Order
 	 */
+	@PublicExperimental
 	public DataSink<T> sortLocalOutput(int field, Order order) {
 
 		if (!this.type.isTupleType()) {
@@ -162,6 +164,7 @@ public class DataSink<T> {
 	 *
 	 * @see Order
 	 */
+	@PublicExperimental
 	public DataSink<T> sortLocalOutput(String fieldExpression, Order order) {
 
 		int numFields;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSource.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DataSource.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.operators;
 
 import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.NonParallelInput;
 import org.apache.flink.api.common.operators.GenericDataSourceBase;
@@ -110,6 +111,7 @@ public class DataSource<OUT> extends Operator<OUT, DataSource<OUT>> {
 	 *
 	 * @return The SplitDataProperties for the InputSplits of this DataSource.
 	 */
+	@PublicExperimental
 	public SplitDataProperties<OUT> getSplitDataProperties() {
 		if(this.splitDataProperties == null) {
 			this.splitDataProperties = new SplitDataProperties<OUT>(this);

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIteration.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.operators;
 
 import java.util.Arrays;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.aggregators.Aggregator;
 import org.apache.flink.api.common.aggregators.AggregatorRegistry;
@@ -39,6 +40,7 @@ import com.google.common.base.Preconditions;
  * @see DataSet#iterateDelta(DataSet, int, int...)
  * @see DataSet#iterateDelta(DataSet, int, int[])
  */
+@PublicInterface
 public class DeltaIteration<ST, WT> {
 	
 	private final AggregatorRegistry aggregators = new AggregatorRegistry();

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIterationResultSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DeltaIterationResultSet.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 
+@PublicInterface
 public class DeltaIterationResultSet<ST, WT> extends DataSet<ST> {
 
 	private DeltaIteration<ST, WT> iterationHead;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/DistinctOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -40,6 +41,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @param <T> The type of the data set made distinct by the operator.
  */
+@PublicInterface
 public class DistinctOperator<T> extends SingleInputOperator<T, T, DistinctOperator<T>> {
 	
 	private final Keys<T> keys;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FilterOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -30,6 +31,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @param <T> The type of the data set filtered by the operator.
  */
+@PublicInterface
 public class FilterOperator<T> extends SingleInputUdfOperator<T, T, FilterOperator<T>> {
 	
 	protected final FilterFunction<T> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/FlatMapOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
@@ -32,6 +33,7 @@ import org.apache.flink.api.java.DataSet;
  * @param <IN> The type of the data set consumed by the operator.
  * @param <OUT> The type of the data set created by the operator.
  */
+@PublicInterface
 public class FlatMapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, FlatMapOperator<IN, OUT>> {
 	
 	protected final FlatMapFunction<IN, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupCombineOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupCombineOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -46,6 +47,7 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
  * @param <IN> The type of the data set consumed by the operator.
  * @param <OUT> The type of the data set created by the operator.
  */
+@PublicInterface
 public class GroupCombineOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, GroupCombineOperator<IN, OUT>> {
 
 	private final GroupCombineFunction<IN, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/GroupReduceOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -47,6 +48,7 @@ import org.apache.flink.api.java.DataSet;
  * @param <IN> The type of the data set consumed by the operator.
  * @param <OUT> The type of the data set created by the operator.
  */
+@PublicInterface
 public class GroupReduceOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, GroupReduceOperator<IN, OUT>> {
 
 	private final GroupReduceFunction<IN, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/Grouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/Grouping.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.java.DataSet;
@@ -35,6 +37,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @see DataSet
  */
+@PublicInterface
 public abstract class Grouping<T> {
 	
 	protected final DataSet<T> dataSet;
@@ -56,12 +59,13 @@ public abstract class Grouping<T> {
 		this.dataSet = set;
 		this.keys = keys;
 	}
-	
-	
+
+	@PublicExperimental
 	public DataSet<T> getDataSet() {
 		return this.dataSet;
 	}
-	
+
+	@PublicExperimental
 	public Keys<T> getKeys() {
 		return this.keys;
 	}
@@ -72,6 +76,7 @@ public abstract class Grouping<T> {
 	 * 
 	 * @return The custom partitioner to be used for this grouping.
 	 */
+	@PublicExperimental
 	public Partitioner<?> getCustomPartitioner() {
 		return this.customPartitioner;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/IterativeDataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/IterativeDataSet.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.aggregators.Aggregator;
 import org.apache.flink.api.common.aggregators.AggregatorRegistry;
@@ -36,6 +38,7 @@ import org.apache.flink.types.Value;
  *
  * @see DataSet#iterate(int)
  */
+@PublicInterface
 public class IterativeDataSet<T> extends SingleInputOperator<T, T, IterativeDataSet<T>> {
 
 	private final AggregatorRegistry aggregators = new AggregatorRegistry();
@@ -103,6 +106,7 @@ public class IterativeDataSet<T> extends SingleInputOperator<T, T, IterativeData
 	 * 
 	 * @return The IterativeDataSet itself, to allow chaining function calls.
 	 */
+	@PublicExperimental
 	public IterativeDataSet<T> registerAggregator(String name, Aggregator<?> aggregator) {
 		this.aggregators.registerAggregator(name, aggregator);
 		return this;
@@ -122,6 +126,7 @@ public class IterativeDataSet<T> extends SingleInputOperator<T, T, IterativeData
 	 * 
 	 * @return The IterativeDataSet itself, to allow chaining function calls.
 	 */
+	@PublicExperimental
 	public <X extends Value> IterativeDataSet<T> registerAggregationConvergenceCriterion(
 			String name, Aggregator<X> aggregator, ConvergenceCriterion<X> convergenceCheck)
 	{
@@ -137,6 +142,7 @@ public class IterativeDataSet<T> extends SingleInputOperator<T, T, IterativeData
 	 * 
 	 * @return The registry for aggregators.
 	 */
+	@PublicExperimental
 	public AggregatorRegistry getAggregators() {
 		return aggregators;
 	}

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/JoinOperator.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
@@ -72,6 +74,7 @@ import org.apache.flink.api.java.tuple.*;
  * 
  * @see DataSet
  */
+@PublicInterface
 public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, I2, OUT, JoinOperator<I1, I2, OUT>> {
 
 	protected final Keys<I1> keys1;
@@ -194,6 +197,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	 * @see org.apache.flink.api.common.functions.RichFlatJoinFunction
 	 * @see DataSet
 	 */
+	@PublicInterface
 	public static class EquiJoin<I1, I2, OUT> extends JoinOperator<I1, I2, OUT> {
 		
 		private final FlatJoinFunction<I1, I2, OUT> function;
@@ -534,6 +538,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	 * @see Tuple2
 	 * @see DataSet
 	 */
+	@PublicInterface
 	public static final class DefaultJoin<I1, I2> extends EquiJoin<I1, I2, Tuple2<I1, I2>> implements JoinFunctionAssigner<I1, I2> {
 
 		public DefaultJoin(DataSet<I1> input1, DataSet<I2> input2,
@@ -667,6 +672,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 	 * @see Tuple
 	 * @see DataSet
 	 */
+	@PublicInterface
 	public static class ProjectJoin<I1, I2, OUT extends Tuple> extends EquiJoin<I1, I2, OUT> {
 		
 		private JoinProjection<I1, I2> joinProj;
@@ -753,6 +759,7 @@ public abstract class JoinOperator<I1, I2, OUT> extends TwoInputUdfOperator<I1, 
 		 */
 		@SuppressWarnings({ "unchecked", "hiding" })
 		@Deprecated
+		@PublicExperimental
 		public <OUT extends Tuple> JoinOperator<I1, I2, OUT> types(Class<?>... types) {
 			TupleTypeInfo<OUT> typeInfo = (TupleTypeInfo<OUT>)this.getResultType();
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapOperator.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
-
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
@@ -35,6 +35,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @see org.apache.flink.api.common.functions.MapFunction
  */
+@PublicInterface
 public class MapOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, MapOperator<IN, OUT>> {
 	
 	protected final MapFunction<IN, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/MapPartitionOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.UnaryOperatorInformation;
@@ -34,6 +35,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @see MapPartitionFunction
  */
+@PublicInterface
 public class MapPartitionOperator<IN, OUT> extends SingleInputUdfOperator<IN, OUT, MapPartitionOperator<IN, OUT>> {
 	
 	protected final MapPartitionFunction<IN, OUT> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/Operator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/Operator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -28,6 +29,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
  * @param <OUT> The type of the data set produced by this operator.
  * @param <O> The type of the operator, so that we can return it.
  */
+@PublicInterface
 public abstract class Operator<OUT, O extends Operator<OUT, O>> extends DataSet<OUT> {
 
 	protected String name;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/PartitionOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Operator;
@@ -40,6 +41,7 @@ import com.google.common.base.Preconditions;
  *
  * @param <T> The type of the data being partitioned.
  */
+@PublicInterface
 public class PartitionOperator<T> extends SingleInputOperator<T, T, PartitionOperator<T>> {
 	
 	private final Keys<T> pKeys;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ProjectOperator.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.java.operators;
 
 import java.util.Arrays;
 
+import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -43,6 +45,7 @@ import com.google.common.base.Preconditions;
  * @param <IN> The type of the data set projected by the operator.
  * @param <OUT> The type of data set that is the result of the projection.
  */
+@PublicInterface
 public class ProjectOperator<IN, OUT extends Tuple> 
 	extends SingleInputOperator<IN, OUT, ProjectOperator<IN, OUT>> {
 	
@@ -72,6 +75,7 @@ public class ProjectOperator<IN, OUT extends Tuple>
 	 */
 	@SuppressWarnings("unchecked")
 	@Deprecated
+	@PublicExperimental
 	public <R extends Tuple> ProjectOperator<IN, R> types(Class<?>... types) {
 		TupleTypeInfo<R> typeInfo = (TupleTypeInfo<R>)this.getResultType();
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/ReduceOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.operators.Operator;
@@ -42,6 +43,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @see org.apache.flink.api.common.functions.ReduceFunction
  */
+@PublicInterface
 public class ReduceOperator<IN> extends SingleInputUdfOperator<IN, IN, ReduceOperator<IN>> {
 	
 	private final ReduceFunction<IN> function;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SortPartitionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SortPartitionOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Order;
@@ -36,6 +37,7 @@ import java.util.Arrays;
  *
  * @param <T> The type of the DataSet with locally sorted partitions.
  */
+@PublicInterface
 public class SortPartitionOperator<T> extends SingleInputOperator<T, T, SortPartitionOperator<T>> {
 
 	private int[] sortKeyPositions;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/SortedGrouping.java
@@ -18,19 +18,19 @@
 
 package org.apache.flink.api.java.operators;
 
+import java.util.Arrays;
+
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
-import org.apache.flink.api.java.Utils;
-import org.apache.flink.api.java.functions.FirstReducer;
-
-import java.util.Arrays;
-
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.Partitioner;
 import org.apache.flink.api.common.operators.Order;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.Utils;
+import org.apache.flink.api.java.functions.FirstReducer;
 import org.apache.flink.api.java.operators.Keys.ExpressionKeys;
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -46,6 +46,7 @@ import com.google.common.base.Preconditions;
  * 
  * @param <T> The type of the elements of the sorted and grouped DataSet.
  */
+@PublicInterface
 public class SortedGrouping<T> extends Grouping<T> {
 	
 	private int[] groupSortKeyPositions;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 
@@ -28,6 +29,7 @@ import org.apache.flink.api.java.DataSet;
  * @param <IN2> The data type of the second input data set.
  * @param <OUT> The data type of the returned data set.
  */
+@PublicInterface
 public abstract class TwoInputOperator<IN1, IN2, OUT, O extends TwoInputOperator<IN1, IN2, OUT, O>> extends Operator<OUT, O> {
 	
 	private final DataSet<IN1> input1;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/TwoInputUdfOperator.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.operators.DualInputSemanticProperties;
@@ -49,6 +50,7 @@ import org.apache.flink.configuration.Configuration;
  * @param <IN2> The data type of the second input data set.
  * @param <OUT> The data type of the returned data set.
  */
+@PublicInterface
 public abstract class TwoInputUdfOperator<IN1, IN2, OUT, O extends TwoInputUdfOperator<IN1, IN2, OUT, O>>
 	extends TwoInputOperator<IN1, IN2, OUT, O> implements UdfOperator<O>
 {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UdfOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UdfOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.operators;
 
 import java.util.Map;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.operators.SemanticProperties;
 import org.apache.flink.configuration.Configuration;
 
@@ -31,6 +32,7 @@ import org.apache.flink.api.java.DataSet;
  * or {@link org.apache.flink.api.common.functions.RichCoGroupFunction}.
  * The UDF operators stand in contrast to operators that execute built-in operations, like aggregations.
  */
+@PublicInterface
 public interface UdfOperator<O extends UdfOperator<O>> {
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnionOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.Union;
@@ -28,6 +29,7 @@ import org.apache.flink.api.java.DataSet;
  * 
  * @param <T> The type of the two input data sets and the result data set 
  */
+@PublicInterface
 public class UnionOperator<T> extends TwoInputOperator<T, T, T, UnionOperator<T>> {
 
 	private final String unionLocationName;

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.GroupCombineFunction;
 import org.apache.flink.api.common.functions.GroupReduceFunction;
@@ -37,6 +38,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 
 import com.google.common.base.Preconditions;
 
+@PublicInterface
 public class UnsortedGrouping<T> extends Grouping<T> {
 
 	public UnsortedGrouping(DataSet<T> set, Keys<T> keys) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinFunctionAssigner.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinFunctionAssigner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators.join;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.java.operators.JoinOperator;
@@ -30,6 +31,7 @@ import org.apache.flink.api.java.operators.JoinOperator;
  * @param <I1> The type of the first input DataSet of the Join transformation.
  * @param <I2> The type of the second input DataSet of the Join transformation.
  */
+@PublicInterface
 public interface JoinFunctionAssigner<I1, I2> {
 
 	<R> JoinOperator<I1, I2, R> with(JoinFunction<I1, I2, R> joinFunction);

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinOperatorSetsBase.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/join/JoinOperatorSetsBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.operators.join;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
@@ -41,6 +42,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
  * @param <I1> The type of the first input DataSet of the Join transformation.
  * @param <I2> The type of the second input DataSet of the Join transformation.
  */
+@PublicInterface
 public class JoinOperatorSetsBase<I1, I2> {
 
 	protected final DataSet<I1> input1;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/Either.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/Either.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.annotation.PublicInterface;
+
 /**
  * This type represents a value of one two possible types, Left or Right (a
  * disjoint union), inspired by Scala's Either type.
@@ -27,6 +29,7 @@ package org.apache.flink.api.java.typeutils;
  * @param <R>
  *            the type of Right
  */
+@PublicInterface
 public abstract class Either<L, R> {
 
 	/**

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -29,6 +30,7 @@ import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
  * @param <L> the Left value type
  * @param <R> the Right value type
  */
+@PublicInterface
 public class EitherTypeInfo<L, R> extends TypeInformation<Either<L, R>> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
@@ -20,12 +20,15 @@ package org.apache.flink.api.java.typeutils;
 
 import java.lang.reflect.Array;
 
-import com.google.common.base.Preconditions;
+import org.apache.flink.annotation.PublicInterface;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
 
+import com.google.common.base.Preconditions;
+
+@PublicInterface
 public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
@@ -19,7 +19,7 @@
 package org.apache.flink.api.java.utils;
 
 import com.google.common.collect.Lists;
-import org.apache.flink.annotation.PublicInterface;
+import org.apache.flink.annotation.PublicExperimental;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.java.DataSet;
@@ -41,7 +41,7 @@ import java.util.List;
  * This class provides simple utility methods for zipping elements in a data set with an index
  * or with a unique identifier.
  */
-@PublicInterface
+@PublicExperimental
 public final class DataSetUtils {
 
 	/**
@@ -253,7 +253,7 @@ public final class DataSetUtils {
 	//     UTIL METHODS
 	// *************************************************************************
 
-	public static int getBitSize(long value){
+	private static int getBitSize(long value){
 		if(value > Integer.MAX_VALUE) {
 			return 64 - Integer.numberOfLeadingZeros((int)(value >> 32));
 		} else {


### PR DESCRIPTION
Changed to Experimental:
- DataSink.sortLocalOutput (should be deprecated, IMO. See FLINK-3186)
- DataSource.getSplitDataProperties
- SplitDataProperties
- DataSetUtils (not sure if we won't move methods out to core API, **discussion please**)

Changed to Public:
- CsvReader
- All subclasses of DataSet, incl. Operator
- Grouping and subclasses
- Either and EitherTypeInfo
- ObjectArrayTypeInfo
- FunctionAnnotation
- DiscardingOF
- TextIF and TextOF
