### PR TITLE
Refinement of Scala DataSet API (flink-scala) annotations

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/UnfinishedCoGroupOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/UnfinishedCoGroupOperation.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.functions.CoGroupFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.operators._
@@ -29,16 +30,17 @@ import scala.reflect.ClassTag
 
 /**
  * An unfinished coGroup operation that results from [[DataSet.coGroup]] The keys for the left and
- * right side must be specified using first `where` and then `isEqualTo`. For example:
+ * right side must be specified using first `where` and then `equalTo`. For example:
  *
  * {{{
  *   val left = ...
  *   val right = ...
- *   val coGroupResult = left.coGroup(right).where(...).isEqualTo(...)
+ *   val coGroupResult = left.coGroup(right).where(...).equalTo(...)
  * }}}
  * @tparam L The type of the left input of the coGroup.
  * @tparam R The type of the right input of the coGroup.
  */
+@PublicInterface
 class UnfinishedCoGroupOperation[L: ClassTag, R: ClassTag](
                                                             leftInput: DataSet[L],
                                                             rightInput: DataSet[R])

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/joinDataSet.scala
@@ -263,6 +263,7 @@ private[flink] abstract class UnfinishedJoinOperationBase[L, R, O <: JoinFunctio
  * @tparam L The type of the left input of the join.
  * @tparam R The type of the right input of the join.
  */
+@PublicInterface
 class UnfinishedJoinOperation[L, R](
     leftSet: DataSet[L],
     rightSet: DataSet[R],
@@ -294,6 +295,7 @@ class UnfinishedJoinOperation[L, R](
  * @tparam L The type of the left input of the join.
  * @tparam R The type of the right input of the join.
  */
+@PublicInterface
 class UnfinishedOuterJoinOperation[L, R](
     leftSet: DataSet[L],
     rightSet: DataSet[R],
@@ -328,6 +330,7 @@ class UnfinishedOuterJoinOperation[L, R](
 
 }
 
+@PublicInterface
 trait JoinFunctionAssigner[L, R] {
 
   def withPartitioner[K : TypeInformation](part : Partitioner[K]) : JoinFunctionAssigner[L, R]

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import java.util
 import java.util.regex.{Pattern, Matcher}
 
@@ -36,6 +37,7 @@ import scala.collection.mutable.ArrayBuffer
  * TypeInformation for Case Classes. Creation and access is different from
  * our Java Tuples so we have to treat them differently.
  */
+@PublicInterface
 abstract class CaseClassTypeInfo[T <: Product](
     clazz: Class[T],
     val typeParamTypeInfos: Array[TypeInformation[_]],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
@@ -26,6 +27,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation [[Either]].
  */
+@PublicInterface
 class EitherTypeInfo[A, B, T <: Either[A, B]](
     val clazz: Class[T],
     val leftTypeInfo: TypeInformation[A],

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
 import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
@@ -26,6 +27,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation for [[Enumeration]] values.
  */
+@PublicInterface
 class EnumValueTypeInfo[E <: Enumeration](val enum: E, val clazz: Class[E#Value])
   extends TypeInformation[E#Value] with AtomicType[E#Value] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
@@ -26,6 +27,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation for [[Option]].
  */
+@PublicInterface
 class OptionTypeInfo[A, T <: Option[A]](private val elemTypeInfo: TypeInformation[A])
   extends TypeInformation[T] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
@@ -17,10 +17,12 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
+@PublicInterface
 class ScalaNothingTypeInfo extends TypeInformation[Nothing] {
 
   override def isBasicType: Boolean = false

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfo.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
@@ -26,6 +27,7 @@ import scala.collection.JavaConverters._
 /**
  * TypeInformation for Scala Collections.
  */
+@PublicInterface
 abstract class TraversableTypeInfo[T <: TraversableOnce[E], E](
     val clazz: Class[T],
     val elementTypeInfo: TypeInformation[E])

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
@@ -28,6 +29,7 @@ import scala.util.Try
 /**
  * TypeInformation for [[scala.util.Try]].
  */
+@PublicInterface
 class TryTypeInfo[A, T <: Try[A]](val elemTypeInfo: TypeInformation[A])
   extends TypeInformation[T] {
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
@@ -17,10 +17,12 @@
  */
 package org.apache.flink.api.scala.typeutils
 
+import org.apache.flink.annotation.PublicInterface
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
 
+@PublicInterface
 class UnitTypeInfo extends TypeInformation[Unit] {
   override def isBasicType(): Boolean = false
   override def isTupleType(): Boolean = false

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/utils/package.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.api.scala
 
-import org.apache.flink.annotation.PublicInterface
+import org.apache.flink.annotation.PublicExperimental
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.Utils
 import org.apache.flink.api.java.utils.{DataSetUtils => jutils}
@@ -35,7 +35,7 @@ package object utils {
    *
    * @param self Data Set
    */
-  @PublicInterface
+  @PublicExperimental
   implicit class DataSetUtils[T: TypeInformation : ClassTag](val self: DataSet[T]) {
 
     /**


### PR DESCRIPTION
- Annotated unfinished operations as `public`
- Annotated all type information in `flink-scala` as `public`
- Changed `public` annotation of Utils to `experimental`
